### PR TITLE
increase audit log length to 120 days

### DIFF
--- a/db/migrate/0028_increase_retention_period.rb
+++ b/db/migrate/0028_increase_retention_period.rb
@@ -1,0 +1,16 @@
+class IncreaseRetentionPeriod < ActiveRecord::Migration
+  NEW_RETENTION_PERIOD = 120 * 86400 # 120 days
+  OLD_RETENTION_PERIOD =  90 * 86400 #  90 days
+
+  def up
+    execute <<~SQL
+      UPDATE audit_log_config SET retention_period = #{NEW_RETENTION_PERIOD}
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE audit_log_config SET retention_period = #{OLD_RETENTION_PERIOD}
+    SQL
+  end
+end


### PR DESCRIPTION
I removed the S3 bucket default deletion policy, so the audit log on S3 will be always go back to at least today.